### PR TITLE
Deploy Javadoc to GitHub Pages

### DIFF
--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -1,0 +1,55 @@
+name: Build and deploy Javadoc
+
+on: [push, pull_request]
+
+jobs:
+  build-javadoc:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: "temurin"
+      
+      # Configure Gradle for optimal use in GiHub Actions, including caching of downloaded dependencies.
+      # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@417ae3ccd767c252f5661f1ace9f835f9654f2b5 # v3.1.0
+      
+      - name: Build Javadoc with Gradle Wrapper
+        run: ./gradlew javadoc
+        
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3.0.1
+        with:
+          # Path of the directory containing the static assets.
+          path: build/docs/javadoc/
+          
+  deploy-javadoc:
+    # Add a dependency to the build job
+    needs: build-javadoc
+
+    # Don't try to deploy from branches or forks
+    if: github.repository_owner == 'roboblazers7617' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
+
+    # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    # Deploy to the github-pages environment
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    # Specify runner + deployment step
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4 # or specific "vX.X.X" version tag for this action


### PR DESCRIPTION
Builds Javadoc with GitHub Actions and deploys to GitHub Pages.

Will need someone to enable GitHub Pages on the repo before this can be merged.